### PR TITLE
Add scalar get/set in gRPC FieldInterface

### DIFF
--- a/GrpcInterface/GrpcInterface_UnitTests/cafGrpcInterfaceBasicTest.cpp
+++ b/GrpcInterface/GrpcInterface_UnitTests/cafGrpcInterfaceBasicTest.cpp
@@ -158,7 +158,8 @@ public:
     }
     caffa::ObjectHandle* execute() override
     {
-        CAFFA_DEBUG( "Executing object method on server" );
+        CAFFA_DEBUG( "Executing object method on server with values: " << m_doubleMember() << ", " << m_intMember()
+                                                                       << ", " << m_stringMember() );
         gsl::not_null<DemoObject*> demoObject = self<DemoObject>();
         demoObject->setDoubleMember( m_doubleMember );
         demoObject->setIntMember( m_intMember );
@@ -349,13 +350,13 @@ TEST( BaseTest, Document )
     ASSERT_TRUE( clientCapability != nullptr );
     ASSERT_EQ( reinterpret_cast<uint64_t>( serverDocument ), clientCapability->addressOnServer() );
 
-    auto serverDescendants = serverDocument->matchingDescendants( []( const caffa::ObjectHandle* objectHandle ) -> bool {
-        return dynamic_cast<const InheritedDemoObj*>( objectHandle ) != nullptr;
-    } );
+    auto serverDescendants = serverDocument->matchingDescendants(
+        []( const caffa::ObjectHandle* objectHandle ) -> bool
+        { return dynamic_cast<const InheritedDemoObj*>( objectHandle ) != nullptr; } );
 
-    auto clientDescendants = clientDocument->matchingDescendants( []( const caffa::ObjectHandle* objectHandle ) -> bool {
-        return dynamic_cast<const InheritedDemoObj*>( objectHandle ) != nullptr;
-    } );
+    auto clientDescendants = clientDocument->matchingDescendants(
+        []( const caffa::ObjectHandle* objectHandle ) -> bool
+        { return dynamic_cast<const InheritedDemoObj*>( objectHandle ) != nullptr; } );
 
     ASSERT_EQ( childCount, serverDescendants.size() );
     ASSERT_EQ( serverDescendants.size(), clientDescendants.size() );

--- a/GrpcInterface/cafGrpcAppService.cpp
+++ b/GrpcInterface/cafGrpcAppService.cpp
@@ -75,7 +75,7 @@ grpc::Status AppService::PerformPing( grpc::ServerContext* context, const NullMe
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<AbstractCallback*> AppService::registerCallbacks()
+std::vector<AbstractCallback*> AppService::createCallbacks()
 {
     typedef AppService Self;
     return { new UnaryCallback<Self, NullMessage, NullMessage>( this, &Self::PerformQuit, &Self::RequestQuit ),

--- a/GrpcInterface/cafGrpcAppService.h
+++ b/GrpcInterface/cafGrpcAppService.h
@@ -42,6 +42,6 @@ public:
     grpc::Status PerformGetAppInfo( grpc::ServerContext* context, const NullMessage* request, AppInfoReply* reply );
     grpc::Status PerformPing( grpc::ServerContext* context, const NullMessage* request, NullMessage* reply );
 
-    std::vector<AbstractCallback*> registerCallbacks() override;
+    std::vector<AbstractCallback*> createCallbacks() override;
 };
 } // namespace caffa::rpc

--- a/GrpcInterface/cafGrpcClient.cpp
+++ b/GrpcInterface/cafGrpcClient.cpp
@@ -171,10 +171,7 @@ public:
 
         SetterRequest setterRequest;
         setterRequest.set_allocated_field( field.release() );
-        if ( jsonValue.is_string() )
-            setterRequest.set_value( jsonValue.get<std::string>() );
-        else
-            setterRequest.set_value( jsonValue.dump() );
+        setterRequest.set_value( jsonValue.dump() );
 
         NullMessage reply;
         auto        status = m_fieldStub->SetValue( &context, setterRequest, &reply );

--- a/GrpcInterface/cafGrpcClient.cpp
+++ b/GrpcInterface/cafGrpcClient.cpp
@@ -101,7 +101,8 @@ public:
         {
             CAFFA_TRACE( "Got document" );
             document = caffa::rpc::ObjectService::createCafObjectFromRpc( &objectReply,
-                                                                          caffa::rpc::GrpcClientObjectFactory::instance() );
+                                                                          caffa::rpc::GrpcClientObjectFactory::instance(),
+                                                                          false );
             CAFFA_TRACE( "Document completed" );
         }
         else
@@ -133,7 +134,8 @@ public:
         if ( status.ok() )
         {
             returnValue = caffa::rpc::ObjectService::createCafObjectFromRpc( &objectReply,
-                                                                             caffa::DefaultObjectFactory::instance() );
+                                                                             caffa::DefaultObjectFactory::instance(),
+                                                                             true );
         }
         return returnValue;
     }

--- a/GrpcInterface/cafGrpcClient.cpp
+++ b/GrpcInterface/cafGrpcClient.cpp
@@ -116,9 +116,9 @@ public:
         auto self   = std::make_unique<Object>();
         auto params = std::make_unique<Object>();
         CAFFA_TRACE( "Copying self" );
-        ObjectService::copyObjectFromCafToRpc( method->self<caffa::ObjectHandle>(), self.get(), false, false );
+        ObjectService::copyProjectObjectFromCafToRpc( method->self<caffa::ObjectHandle>(), self.get() );
         CAFFA_TRACE( "Copying parameters" );
-        ObjectService::copyObjectFromCafToRpc( method, params.get(), true, true );
+        ObjectService::copyResultOrParameterObjectFromCafToRpc( method, params.get() );
 
         grpc::ClientContext context;
         MethodRequest       request;
@@ -161,7 +161,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
 
         auto field = std::make_unique<FieldRequest>();
         field->set_method( fieldName );
@@ -188,7 +188,7 @@ public:
         CAFFA_TRACE( "Get JSON value for field " << fieldName );
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
         FieldRequest field;
         field.set_method( fieldName );
         field.set_allocated_self( self.release() );
@@ -214,7 +214,7 @@ public:
 
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
 
         auto field = std::make_unique<FieldRequest>();
         field->set_method( setter );
@@ -259,7 +259,7 @@ public:
 
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
 
         auto field = std::make_unique<FieldRequest>();
         field->set_method( setter );
@@ -306,7 +306,7 @@ public:
         CAFFA_TRACE( "Sending " << values.size() << " double values from client" );
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
 
         auto field = std::make_unique<FieldRequest>();
         field->set_method( setter );
@@ -352,7 +352,7 @@ public:
 
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
 
         auto field = std::make_unique<FieldRequest>();
         field->set_method( setter );
@@ -396,7 +396,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
 
         auto field = std::make_unique<FieldRequest>();
         field->set_method( setter );
@@ -432,7 +432,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
         FieldRequest field;
         field.set_method( getter );
         field.set_allocated_self( self.release() );
@@ -458,7 +458,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
         FieldRequest field;
         field.set_method( getter );
         field.set_allocated_self( self.release() );
@@ -485,7 +485,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
         FieldRequest field;
         field.set_method( getter );
         field.set_allocated_self( self.release() );
@@ -512,7 +512,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
         FieldRequest field;
         field.set_method( getter );
         field.set_allocated_self( self.release() );
@@ -545,7 +545,7 @@ public:
     {
         grpc::ClientContext context;
         auto                self = std::make_unique<Object>();
-        ObjectService::copyObjectFromCafToRpc( objectHandle, self.get(), false );
+        ObjectService::copyProjectObjectFromCafToRpc( objectHandle, self.get() );
         FieldRequest field;
         field.set_method( getter );
         field.set_allocated_self( self.release() );

--- a/GrpcInterface/cafGrpcFieldService.cpp
+++ b/GrpcInterface/cafGrpcFieldService.cpp
@@ -586,7 +586,15 @@ grpc::Status FieldService::GetValue( grpc::ServerContext* context, const FieldRe
                 nlohmann::json jsonValue;
 
                 ioCapability->readFromField( jsonValue, true, true );
-                reply->set_value( jsonValue.dump() );
+                if ( jsonValue.is_string() )
+                {
+                    reply->set_value( jsonValue.get<std::string>() );
+                }
+                else
+                {
+                    reply->set_value( jsonValue.dump() );
+                }
+                CAFFA_DEBUG( "Sending value: " << reply->value() );
                 return grpc::Status::OK;
             }
         }

--- a/GrpcInterface/cafGrpcFieldService.cpp
+++ b/GrpcInterface/cafGrpcFieldService.cpp
@@ -586,15 +586,8 @@ grpc::Status FieldService::GetValue( grpc::ServerContext* context, const FieldRe
                 nlohmann::json jsonValue;
 
                 ioCapability->readFromField( jsonValue, true, true );
-                if ( jsonValue.is_string() )
-                {
-                    reply->set_value( jsonValue.get<std::string>() );
-                }
-                else
-                {
-                    reply->set_value( jsonValue.dump() );
-                }
-                CAFFA_DEBUG( "Sending value: " << reply->value() );
+                reply->set_value( jsonValue.dump() );
+                CAFFA_DEBUG( "Sending value: '" << reply->value() << "'" );
                 return grpc::Status::OK;
             }
         }
@@ -635,8 +628,8 @@ grpc::Status FieldService::SetValue( grpc::ServerContext* context, const SetterR
             auto ioCapability = field->capability<caffa::FieldIoCapability>();
             if ( ioCapability )
             {
-                nlohmann::json jsonValue = request->value();
-                CAFFA_DEBUG( "   With value: " << request->value() );
+                auto jsonValue = nlohmann::json::parse( request->value() );
+                CAFFA_DEBUG( "   With value: '" << request->value() << "'" );
                 ioCapability->writeToField( jsonValue, caffa::DefaultObjectFactory::instance(), true );
                 return grpc::Status::OK;
             }

--- a/GrpcInterface/cafGrpcFieldService.cpp
+++ b/GrpcInterface/cafGrpcFieldService.cpp
@@ -63,9 +63,14 @@ struct DataHolder : public AbstractDataHolder
     size_t valueCount() const override;
     size_t valueSizeOf() const override;
 
-    void reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const override;
-    // Default implementation deals with scalar values
-    void addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const override;
+    void reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const override
+    {
+        static_assert( "Should never be called!" );
+    }
+    void addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const override
+    {
+        static_assert( "Should never be called!" );
+    }
 
     size_t                getValuesFromChunk( size_t startIndex, const SetterChunk* chunk ) override;
     void                  applyValuesToField( ValueField* field ) override;
@@ -320,9 +325,6 @@ GetterStateHandler::GetterStateHandler()
 //--------------------------------------------------------------------------------------------------
 grpc::Status GetterStateHandler::init( const FieldRequest* request )
 {
-    CAFFA_DEBUG( "Received Get Array Request for: " << request->self().class_keyword() << "[0x" << std::hex
-                                                    << request->self().address() << "]" << request->method() );
-
     m_fieldOwner = ObjectService::findCafObjectFromRpcObject( request->self() );
     CAFFA_ASSERT( m_fieldOwner );
     if ( !m_fieldOwner ) return grpc::Status( grpc::NOT_FOUND, "Object not found" );
@@ -442,10 +444,6 @@ grpc::Status SetterStateHandler::init( const SetterChunk* chunk )
 {
     CAFFA_ASSERT( chunk->has_set_request() );
     auto setRequest = chunk->set_request();
-
-    CAFFA_DEBUG( "Received Set Request for: " << setRequest.field().self().class_keyword() << "[0x" << std::hex
-                                              << setRequest.field().self().address() << "]->"
-                                              << setRequest.field().method() );
 
     auto fieldRequest = setRequest.field();
     m_fieldOwner      = ObjectService::findCafObjectFromRpcObject( fieldRequest.self() );

--- a/GrpcInterface/cafGrpcFieldService.cpp
+++ b/GrpcInterface/cafGrpcFieldService.cpp
@@ -616,6 +616,9 @@ grpc::Status FieldService::SetValue( grpc::ServerContext* context, const SetterR
     auto fieldOwner   = ObjectService::findCafObjectFromRpcObject( fieldRequest.self() );
     CAFFA_ASSERT( fieldOwner );
     if ( !fieldOwner ) return grpc::Status( grpc::NOT_FOUND, "Object not found" );
+
+    CAFFA_DEBUG( "Received Set Request for class " << fieldOwner->classKeyword() );
+
     for ( auto field : fieldOwner->fields() )
     {
         auto scriptability = field->capability<FieldScriptingCapability>();
@@ -625,7 +628,8 @@ grpc::Status FieldService::SetValue( grpc::ServerContext* context, const SetterR
             if ( ioCapability )
             {
                 nlohmann::json jsonValue = request->value();
-                ioCapability->writeToField( jsonValue, caffa::DefaultObjectFactory::instance() );
+                CAFFA_DEBUG( "   With value: " << request->value() );
+                ioCapability->writeToField( jsonValue, caffa::DefaultObjectFactory::instance(), true );
                 return grpc::Status::OK;
             }
         }

--- a/GrpcInterface/cafGrpcFieldService.cpp
+++ b/GrpcInterface/cafGrpcFieldService.cpp
@@ -55,7 +55,7 @@ namespace caffa::rpc
 template <typename DataType>
 struct DataHolder : public AbstractDataHolder
 {
-    DataHolder( const DataType& data )
+    DataHolder( const std::vector<DataType>& data )
         : data( data )
     {
     }
@@ -63,45 +63,41 @@ struct DataHolder : public AbstractDataHolder
     size_t valueCount() const override;
     size_t valueSizeOf() const override;
 
-    void reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const override {}
+    void reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const override;
     // Default implementation deals with scalar values
-    void addPackageValuesToReply( GetterReply* reply, size_t startIndex, size_t numberOfDataUnits ) const override
-    {
-        CAFFA_TRACE( "Assign scalar result of type: " << typeid( DataType ).name() << " with value " << data );
-        reply->set_scalar( data );
-    }
+    void addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const override;
 
-    size_t   getValuesFromChunk( size_t startIndex, const SetterChunk* chunk ) override;
-    void     applyValuesToField( ValueField* field ) override;
-    DataType data;
+    size_t                getValuesFromChunk( size_t startIndex, const SetterChunk* chunk ) override;
+    void                  applyValuesToField( ValueField* field ) override;
+    std::vector<DataType> data;
 };
 
 template <>
-size_t DataHolder<std::vector<int>>::valueCount() const
+size_t DataHolder<int>::valueCount() const
 {
     return data.size();
 }
 template <>
-size_t DataHolder<std::vector<int>>::valueSizeOf() const
+size_t DataHolder<int>::valueSizeOf() const
 {
     return sizeof( int );
 }
 
 template <>
-void DataHolder<std::vector<int>>::reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const
+void DataHolder<int>::reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const
 {
     reply->mutable_ints()->mutable_data()->Reserve( numberOfDataUnits );
 }
 
 template <>
-void DataHolder<std::vector<int>>::addPackageValuesToReply( GetterReply* reply, size_t startIndex, size_t numberOfDataUnits ) const
+void DataHolder<int>::addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const
 {
     *( reply->mutable_ints()->mutable_data() ) = { data.begin() + startIndex,
                                                    data.begin() + startIndex + numberOfDataUnits };
 }
 
 template <>
-size_t DataHolder<std::vector<int>>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
+size_t DataHolder<int>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
 {
     size_t chunkSize    = chunk->ints().data_size();
     size_t currentIndex = startIndex;
@@ -113,7 +109,7 @@ size_t DataHolder<std::vector<int>>::getValuesFromChunk( size_t startIndex, cons
     return chunkSize;
 }
 template <>
-void DataHolder<std::vector<int>>::applyValuesToField( ValueField* field )
+void DataHolder<int>::applyValuesToField( ValueField* field )
 {
     auto dataValueField = dynamic_cast<Field<std::vector<int>>*>( field );
     if ( dataValueField )
@@ -124,33 +120,31 @@ void DataHolder<std::vector<int>>::applyValuesToField( ValueField* field )
 }
 
 template <>
-size_t DataHolder<std::vector<uint64_t>>::valueCount() const
+size_t DataHolder<uint64_t>::valueCount() const
 {
     return data.size();
 }
 template <>
-size_t DataHolder<std::vector<uint64_t>>::valueSizeOf() const
+size_t DataHolder<uint64_t>::valueSizeOf() const
 {
     return sizeof( uint64_t );
 }
 
 template <>
-void DataHolder<std::vector<uint64_t>>::reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const
+void DataHolder<uint64_t>::reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const
 {
     reply->mutable_uint64s()->mutable_data()->Reserve( numberOfDataUnits );
 }
 
 template <>
-void DataHolder<std::vector<uint64_t>>::addPackageValuesToReply( GetterReply* reply,
-                                                                 size_t       startIndex,
-                                                                 size_t       numberOfDataUnits ) const
+void DataHolder<uint64_t>::addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const
 {
     *( reply->mutable_uint64s()->mutable_data() ) = { data.begin() + startIndex,
                                                       data.begin() + startIndex + numberOfDataUnits };
 }
 
 template <>
-size_t DataHolder<std::vector<uint64_t>>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
+size_t DataHolder<uint64_t>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
 {
     size_t chunkSize    = chunk->uint64s().data_size();
     size_t currentIndex = startIndex;
@@ -162,7 +156,7 @@ size_t DataHolder<std::vector<uint64_t>>::getValuesFromChunk( size_t startIndex,
     return chunkSize;
 }
 template <>
-void DataHolder<std::vector<uint64_t>>::applyValuesToField( ValueField* field )
+void DataHolder<uint64_t>::applyValuesToField( ValueField* field )
 {
     auto dataValueField = dynamic_cast<Field<std::vector<uint64_t>>*>( field );
     if ( dataValueField )
@@ -173,32 +167,30 @@ void DataHolder<std::vector<uint64_t>>::applyValuesToField( ValueField* field )
 }
 
 template <>
-size_t DataHolder<std::vector<double>>::valueCount() const
+size_t DataHolder<double>::valueCount() const
 {
     return data.size();
 }
 template <>
-size_t DataHolder<std::vector<double>>::valueSizeOf() const
+size_t DataHolder<double>::valueSizeOf() const
 {
     return sizeof( double );
 }
 
 template <>
-void DataHolder<std::vector<double>>::reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const
+void DataHolder<double>::reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const
 {
     reply->mutable_doubles()->mutable_data()->Reserve( numberOfDataUnits );
 }
 
 template <>
-void DataHolder<std::vector<double>>::addPackageValuesToReply( GetterReply* reply,
-                                                               size_t       startIndex,
-                                                               size_t       numberOfDataUnits ) const
+void DataHolder<double>::addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const
 {
     *( reply->mutable_doubles()->mutable_data() ) = { data.begin() + startIndex,
                                                       data.begin() + startIndex + numberOfDataUnits };
 }
 template <>
-size_t DataHolder<std::vector<double>>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
+size_t DataHolder<double>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
 {
     size_t chunkSize    = chunk->doubles().data_size();
     size_t currentIndex = startIndex;
@@ -210,7 +202,7 @@ size_t DataHolder<std::vector<double>>::getValuesFromChunk( size_t startIndex, c
     return chunkSize;
 }
 template <>
-void DataHolder<std::vector<double>>::applyValuesToField( ValueField* field )
+void DataHolder<double>::applyValuesToField( ValueField* field )
 {
     auto dataValueField = dynamic_cast<Field<std::vector<double>>*>( field );
     if ( dataValueField )
@@ -220,33 +212,31 @@ void DataHolder<std::vector<double>>::applyValuesToField( ValueField* field )
     }
 }
 template <>
-size_t DataHolder<std::vector<float>>::valueCount() const
+size_t DataHolder<float>::valueCount() const
 {
     return data.size();
 }
 template <>
-size_t DataHolder<std::vector<float>>::valueSizeOf() const
+size_t DataHolder<float>::valueSizeOf() const
 {
     return sizeof( float );
 }
 
 template <>
-void DataHolder<std::vector<float>>::reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const
+void DataHolder<float>::reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const
 {
     reply->mutable_floats()->mutable_data()->Reserve( numberOfDataUnits );
 }
 
 template <>
-void DataHolder<std::vector<float>>::addPackageValuesToReply( GetterReply* reply,
-                                                              size_t       startIndex,
-                                                              size_t       numberOfDataUnits ) const
+void DataHolder<float>::addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const
 {
     *( reply->mutable_floats()->mutable_data() ) = { data.begin() + startIndex,
                                                      data.begin() + startIndex + numberOfDataUnits };
 }
 
 template <>
-size_t DataHolder<std::vector<float>>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
+size_t DataHolder<float>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
 {
     size_t chunkSize    = chunk->floats().data_size();
     size_t currentIndex = startIndex;
@@ -258,7 +248,7 @@ size_t DataHolder<std::vector<float>>::getValuesFromChunk( size_t startIndex, co
     return chunkSize;
 }
 template <>
-void DataHolder<std::vector<float>>::applyValuesToField( ValueField* field )
+void DataHolder<float>::applyValuesToField( ValueField* field )
 {
     auto dataValueField = dynamic_cast<Field<std::vector<float>>*>( field );
     if ( dataValueField )
@@ -269,33 +259,31 @@ void DataHolder<std::vector<float>>::applyValuesToField( ValueField* field )
 }
 
 template <>
-size_t DataHolder<std::vector<std::string>>::valueCount() const
+size_t DataHolder<std::string>::valueCount() const
 {
     return data.size();
 }
 template <>
-size_t DataHolder<std::vector<std::string>>::valueSizeOf() const
+size_t DataHolder<std::string>::valueSizeOf() const
 {
     return sizeof( std::string );
 }
 
 template <>
-void DataHolder<std::vector<std::string>>::reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const
+void DataHolder<std::string>::reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const
 {
     reply->mutable_strings()->mutable_data()->Reserve( numberOfDataUnits );
 }
 
 template <>
-void DataHolder<std::vector<std::string>>::addPackageValuesToReply( GetterReply* reply,
-                                                                    size_t       startIndex,
-                                                                    size_t       numberOfDataUnits ) const
+void DataHolder<std::string>::addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const
 {
     *( reply->mutable_strings()->mutable_data() ) = { data.begin() + startIndex,
                                                       data.begin() + startIndex + numberOfDataUnits };
 }
 
 template <>
-size_t DataHolder<std::vector<std::string>>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
+size_t DataHolder<std::string>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
 {
     size_t chunkSize    = 1u;
     size_t currentIndex = startIndex;
@@ -307,7 +295,7 @@ size_t DataHolder<std::vector<std::string>>::getValuesFromChunk( size_t startInd
     return chunkSize;
 }
 template <>
-void DataHolder<std::vector<std::string>>::applyValuesToField( ValueField* field )
+void DataHolder<std::string>::applyValuesToField( ValueField* field )
 {
     auto dataValueField = dynamic_cast<Field<std::vector<std::string>>*>( field );
     if ( dataValueField )
@@ -315,32 +303,6 @@ void DataHolder<std::vector<std::string>>::applyValuesToField( ValueField* field
         CAFFA_TRACE( "Applying " << data.size() << " values to field" );
         dataValueField->setValueWithFieldChanged( data, dataValueField->capability<FieldScriptingCapability>() );
     }
-}
-
-template <>
-size_t DataHolder<std::string>::valueCount() const
-{
-    return 1u;
-}
-template <>
-size_t DataHolder<std::string>::valueSizeOf() const
-{
-    return sizeof( std::string );
-}
-
-template <>
-size_t DataHolder<std::string>::getValuesFromChunk( size_t startIndex, const SetterChunk* chunk )
-{
-    auto scalar = chunk->scalar();
-    data        = scalar;
-    return 1u;
-}
-template <>
-void DataHolder<std::string>::applyValuesToField( ValueField* field )
-{
-    auto ioCapability = field->capability<FieldIoCapability>();
-    CAFFA_ASSERT( ioCapability );
-    ioCapability->writeToField( data, caffa::DefaultObjectFactory::instance() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -358,8 +320,8 @@ GetterStateHandler::GetterStateHandler()
 //--------------------------------------------------------------------------------------------------
 grpc::Status GetterStateHandler::init( const FieldRequest* request )
 {
-    CAFFA_DEBUG( "Received Get Request for: " << request->self().class_keyword() << "[0x" << std::hex
-                                              << request->self().address() << "]" << request->method() );
+    CAFFA_DEBUG( "Received Get Array Request for: " << request->self().class_keyword() << "[0x" << std::hex
+                                                    << request->self().address() << "]" << request->method() );
 
     m_fieldOwner = ObjectService::findCafObjectFromRpcObject( request->self() );
     CAFFA_ASSERT( m_fieldOwner );
@@ -372,42 +334,32 @@ grpc::Status GetterStateHandler::init( const FieldRequest* request )
             if ( auto dataField = dynamic_cast<TypedValueField<std::vector<int>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<int>>( dataField->value() ) );
+                m_dataHolder.reset( new DataHolder<int>( dataField->value() ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<uint64_t>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<uint64_t>>( dataField->value() ) );
+                m_dataHolder.reset( new DataHolder<uint64_t>( dataField->value() ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<double>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<double>>( dataField->value() ) );
+                m_dataHolder.reset( new DataHolder<double>( dataField->value() ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<float>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<float>>( dataField->value() ) );
+                m_dataHolder.reset( new DataHolder<float>( dataField->value() ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<std::string>>*>( field );
                       dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<std::string>>( dataField->value() ) );
-                return grpc::Status::OK;
-            }
-            else if ( auto dataField = dynamic_cast<ValueField*>( field ); dataField != nullptr )
-            {
-                m_field = dataField;
-                nlohmann::json jsonValue;
-                auto           ioCapability = field->capability<caffa::FieldIoCapability>();
-                ioCapability->readFromField( jsonValue, true, true );
-                std::cout << "Json value: " << jsonValue.dump() << std::endl;
-                m_dataHolder.reset( new DataHolder<std::string>( jsonValue.dump() ) );
+                m_dataHolder.reset( new DataHolder<std::string>( dataField->value() ) );
                 return grpc::Status::OK;
             }
             else
@@ -423,7 +375,7 @@ grpc::Status GetterStateHandler::init( const FieldRequest* request )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-grpc::Status GetterStateHandler::assignReply( GetterReply* reply )
+grpc::Status GetterStateHandler::assignReply( GetterArrayReply* reply )
 {
     CAFFA_ASSERT( m_dataHolder );
 
@@ -491,11 +443,11 @@ grpc::Status SetterStateHandler::init( const SetterChunk* chunk )
     CAFFA_ASSERT( chunk->has_set_request() );
     auto setRequest = chunk->set_request();
 
-    CAFFA_DEBUG( "Received Set Request for: " << setRequest.request().self().class_keyword() << "[0x" << std::hex
-                                              << setRequest.request().self().address() << "]->"
-                                              << setRequest.request().method() );
+    CAFFA_DEBUG( "Received Set Request for: " << setRequest.field().self().class_keyword() << "[0x" << std::hex
+                                              << setRequest.field().self().address() << "]->"
+                                              << setRequest.field().method() );
 
-    auto fieldRequest = setRequest.request();
+    auto fieldRequest = setRequest.field();
     m_fieldOwner      = ObjectService::findCafObjectFromRpcObject( fieldRequest.self() );
     int valueCount    = setRequest.value_count();
 
@@ -507,39 +459,33 @@ grpc::Status SetterStateHandler::init( const SetterChunk* chunk )
             if ( auto dataField = dynamic_cast<TypedValueField<std::vector<int>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<int>>( std::vector<int>( valueCount ) ) );
+                m_dataHolder.reset( new DataHolder<int>( std::vector<int>( valueCount ) ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<uint64_t>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<uint64_t>>( std::vector<uint64_t>( valueCount ) ) );
+                m_dataHolder.reset( new DataHolder<uint64_t>( std::vector<uint64_t>( valueCount ) ) );
                 return grpc::Status::OK;
             }
 
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<double>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<double>>( std::vector<double>( valueCount ) ) );
+                m_dataHolder.reset( new DataHolder<double>( std::vector<double>( valueCount ) ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<float>>*>( field ); dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<float>>( std::vector<float>( valueCount ) ) );
+                m_dataHolder.reset( new DataHolder<float>( std::vector<float>( valueCount ) ) );
                 return grpc::Status::OK;
             }
             else if ( auto dataField = dynamic_cast<TypedValueField<std::vector<std::string>>*>( field );
                       dataField != nullptr )
             {
                 m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::vector<std::string>>( std::vector<std::string>( valueCount ) ) );
-                return grpc::Status::OK;
-            }
-            else if ( auto dataField = dynamic_cast<ValueField*>( field ); dataField != nullptr )
-            {
-                m_field = dataField;
-                m_dataHolder.reset( new DataHolder<std::string>( std::string() ) );
+                m_dataHolder.reset( new DataHolder<std::string>( std::vector<std::string>( valueCount ) ) );
                 return grpc::Status::OK;
             }
             else
@@ -554,7 +500,7 @@ grpc::Status SetterStateHandler::init( const SetterChunk* chunk )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-grpc::Status SetterStateHandler::receiveRequest( const SetterChunk* chunk, SetterReply* reply )
+grpc::Status SetterStateHandler::receiveRequest( const SetterChunk* chunk, SetterArrayReply* reply )
 {
     CAFFA_TRACE( "Received Setter Chunk" );
 
@@ -613,10 +559,10 @@ StateHandler<SetterChunk>* SetterStateHandler::emptyClone() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-grpc::Status FieldService::GetValue( grpc::ServerContext*        context,
-                                     const FieldRequest*         request,
-                                     GetterReply*                reply,
-                                     StateHandler<FieldRequest>* stateHandler )
+grpc::Status FieldService::GetArrayValue( grpc::ServerContext*        context,
+                                          const FieldRequest*         request,
+                                          GetterArrayReply*           reply,
+                                          StateHandler<FieldRequest>* stateHandler )
 {
     auto getterHandler = dynamic_cast<GetterStateHandler*>( stateHandler );
     CAFFA_ASSERT( getterHandler );
@@ -626,10 +572,37 @@ grpc::Status FieldService::GetValue( grpc::ServerContext*        context,
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-grpc::Status FieldService::SetValue( grpc::ServerContext*       context,
-                                     const SetterChunk*         chunk,
-                                     SetterReply*               reply,
-                                     StateHandler<SetterChunk>* stateHandler )
+grpc::Status FieldService::GetValue( grpc::ServerContext* context, const FieldRequest* request, GetterReply* reply )
+{
+    auto fieldOwner = ObjectService::findCafObjectFromRpcObject( request->self() );
+    CAFFA_ASSERT( fieldOwner );
+    if ( !fieldOwner ) return grpc::Status( grpc::NOT_FOUND, "Object not found" );
+    for ( auto field : fieldOwner->fields() )
+    {
+        auto scriptability = field->capability<FieldScriptingCapability>();
+        if ( scriptability && request->method() == scriptability->scriptFieldName() )
+        {
+            auto ioCapability = field->capability<caffa::FieldIoCapability>();
+            if ( ioCapability )
+            {
+                nlohmann::json jsonValue;
+
+                ioCapability->readFromField( jsonValue, true, true );
+                reply->set_value( jsonValue.dump() );
+                return grpc::Status::OK;
+            }
+        }
+    }
+    return grpc::Status( grpc::NOT_FOUND, "Field not found" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+grpc::Status FieldService::SetArrayValue( grpc::ServerContext*       context,
+                                          const SetterChunk*         chunk,
+                                          SetterArrayReply*          reply,
+                                          StateHandler<SetterChunk>* stateHandler )
 {
     auto setterHandler = dynamic_cast<SetterStateHandler*>( stateHandler );
     CAFFA_ASSERT( setterHandler );
@@ -639,19 +612,45 @@ grpc::Status FieldService::SetValue( grpc::ServerContext*       context,
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<AbstractCallback*> FieldService::registerCallbacks()
+grpc::Status FieldService::SetValue( grpc::ServerContext* context, const SetterRequest* request, NullMessage* reply )
+{
+    auto fieldRequest = request->field();
+    auto fieldOwner   = ObjectService::findCafObjectFromRpcObject( fieldRequest.self() );
+    CAFFA_ASSERT( fieldOwner );
+    if ( !fieldOwner ) return grpc::Status( grpc::NOT_FOUND, "Object not found" );
+    for ( auto field : fieldOwner->fields() )
+    {
+        auto scriptability = field->capability<FieldScriptingCapability>();
+        if ( scriptability && fieldRequest.method() == scriptability->scriptFieldName() )
+        {
+            auto ioCapability = field->capability<caffa::FieldIoCapability>();
+            if ( ioCapability )
+            {
+                nlohmann::json jsonValue = request->value();
+                ioCapability->writeToField( jsonValue, caffa::DefaultObjectFactory::instance() );
+                return grpc::Status::OK;
+            }
+        }
+    }
+    return grpc::Status( grpc::NOT_FOUND, "Field not found" );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::vector<AbstractCallback*> FieldService::createCallbacks()
 {
     typedef FieldService Self;
-    return {
-        new ServerToClientStreamCallback<Self, FieldRequest, GetterReply>( this,
-                                                                           &Self::GetValue,
-                                                                           &Self::RequestGetValue,
-                                                                           new GetterStateHandler ),
-        new ClientToServerStreamCallback<Self, SetterChunk, SetterReply>( this,
-                                                                          &Self::SetValue,
-                                                                          &Self::RequestSetValue,
-                                                                          new SetterStateHandler ),
-    };
+    return { new ServerToClientStreamCallback<Self, FieldRequest, GetterArrayReply>( this,
+                                                                                     &Self::GetArrayValue,
+                                                                                     &Self::RequestGetArrayValue,
+                                                                                     new GetterStateHandler ),
+             new ClientToServerStreamCallback<Self, SetterChunk, SetterArrayReply>( this,
+                                                                                    &Self::SetArrayValue,
+                                                                                    &Self::RequestSetArrayValue,
+                                                                                    new SetterStateHandler ),
+             new UnaryCallback<Self, FieldRequest, GetterReply>( this, &Self::GetValue, &Self::RequestGetValue ),
+             new UnaryCallback<Self, SetterRequest, NullMessage>( this, &Self::SetValue, &Self::RequestSetValue ) };
 }
 
 } // namespace caffa::rpc

--- a/GrpcInterface/cafGrpcFieldService.h
+++ b/GrpcInterface/cafGrpcFieldService.h
@@ -41,20 +41,20 @@ class ValueField;
 
 namespace caffa::rpc
 {
-class GetterReply;
+class GetterArrayReply;
 class FieldRequest;
 class SetterChunk;
-class SetterReply;
+class SetterArrayReply;
 
 struct AbstractDataHolder
 {
-    virtual size_t valueCount() const                                                                               = 0;
-    virtual size_t valueSizeOf() const                                                                              = 0;
-    virtual void   reserveReplyStorage( GetterReply* reply, size_t numberOfDataUnits ) const                        = 0;
-    virtual void   addPackageValuesToReply( GetterReply* reply, size_t startIndex, size_t numberOfDataUnits ) const = 0;
+    virtual size_t valueCount() const                                                             = 0;
+    virtual size_t valueSizeOf() const                                                            = 0;
+    virtual void   reserveReplyStorage( GetterArrayReply* reply, size_t numberOfDataUnits ) const = 0;
+    virtual void addPackageValuesToReply( GetterArrayReply* reply, size_t startIndex, size_t numberOfDataUnits ) const = 0;
 
     virtual size_t getValuesFromChunk( size_t startIndex, const SetterChunk* chunk ) = 0;
-    virtual void   applyValuesToField( caffa::ValueField* field )                      = 0;
+    virtual void   applyValuesToField( caffa::ValueField* field )                    = 0;
 };
 
 /**
@@ -68,7 +68,7 @@ public:
     GetterStateHandler();
 
     grpc::Status init( const FieldRequest* request ) override;
-    grpc::Status assignReply( GetterReply* reply );
+    grpc::Status assignReply( GetterArrayReply* reply );
     size_t       streamedValueCount() const override;
     size_t       totalValueCount() const override;
     void         finish() override;
@@ -76,8 +76,8 @@ public:
     StateHandler<FieldRequest>* emptyClone() const override;
 
 protected:
-    caffa::Object*                        m_fieldOwner;
-    caffa::ValueField*                    m_field;
+    caffa::Object*                      m_fieldOwner;
+    caffa::ValueField*                  m_field;
     std::unique_ptr<AbstractDataHolder> m_dataHolder;
     size_t                              m_currentDataIndex;
 };
@@ -93,7 +93,7 @@ public:
     SetterStateHandler();
 
     grpc::Status init( const SetterChunk* chunk ) override;
-    grpc::Status receiveRequest( const SetterChunk* chunk, SetterReply* reply );
+    grpc::Status receiveRequest( const SetterChunk* chunk, SetterArrayReply* reply );
     size_t       streamedValueCount() const override;
     size_t       totalValueCount() const override;
     void         finish() override;
@@ -101,8 +101,8 @@ public:
     StateHandler<SetterChunk>* emptyClone() const override;
 
 protected:
-    caffa::Object*                        m_fieldOwner;
-    caffa::ValueField*                    m_field;
+    caffa::Object*                      m_fieldOwner;
+    caffa::ValueField*                  m_field;
     std::unique_ptr<AbstractDataHolder> m_dataHolder;
     size_t                              m_currentDataIndex;
 };
@@ -115,17 +115,20 @@ protected:
 class FieldService final : public FieldAccess::AsyncService, public ServiceInterface
 {
 public:
-    grpc::Status GetValue( grpc::ServerContext*        context,
-                           const FieldRequest*         request,
-                           GetterReply*                reply,
-                           StateHandler<FieldRequest>* stateHandler );
+    grpc::Status GetArrayValue( grpc::ServerContext*        context,
+                                const FieldRequest*         request,
+                                GetterArrayReply*           reply,
+                                StateHandler<FieldRequest>* stateHandler );
 
-    grpc::Status SetValue( grpc::ServerContext*       context,
-                           const SetterChunk*         chunk,
-                           SetterReply*               reply,
-                           StateHandler<SetterChunk>* stateHandler );
+    grpc::Status GetValue( grpc::ServerContext* context, const FieldRequest* request, GetterReply* reply );
 
-    std::vector<AbstractCallback*> registerCallbacks() override;
+    grpc::Status SetArrayValue( grpc::ServerContext*       context,
+                                const SetterChunk*         chunk,
+                                SetterArrayReply*          reply,
+                                StateHandler<SetterChunk>* stateHandler );
+
+    grpc::Status SetValue( grpc::ServerContext* context, const SetterRequest* request, NullMessage* reply );
+    std::vector<AbstractCallback*> createCallbacks() override;
 };
 
 } // namespace caffa::rpc

--- a/GrpcInterface/cafGrpcFieldService.h
+++ b/GrpcInterface/cafGrpcFieldService.h
@@ -42,9 +42,11 @@ class ValueField;
 namespace caffa::rpc
 {
 class GetterArrayReply;
+class GetterReply;
 class FieldRequest;
 class SetterChunk;
 class SetterArrayReply;
+class SetterReply;
 
 struct AbstractDataHolder
 {

--- a/GrpcInterface/cafGrpcObjectService.cpp
+++ b/GrpcInterface/cafGrpcObjectService.cpp
@@ -133,8 +133,9 @@ caffa::Object* ObjectService::findCafObjectFromScriptNameAndAddress( const std::
 
     for ( auto doc : ServerApplication::instance()->documents() )
     {
-        std::list<caffa::ObjectHandle*> objects =
-            doc->matchingDescendants( [scriptClassName]( const caffa::ObjectHandle* objectHandle ) -> bool {
+        std::list<caffa::ObjectHandle*> objects = doc->matchingDescendants(
+            [scriptClassName]( const caffa::ObjectHandle* objectHandle ) -> bool
+            {
                 auto ioCapability = objectHandle->capability<caffa::ObjectIoCapability>();
                 return ioCapability ? ioCapability->classKeyword() == scriptClassName : false;
             } );
@@ -165,9 +166,9 @@ caffa::Object* ObjectService::findCafObjectFromScriptNameAndAddress( const std::
 ///
 //--------------------------------------------------------------------------------------------------
 void ObjectService::copyObjectFromCafToRpc( const caffa::ObjectHandle* source,
-                                            Object*                  destination,
-                                            bool                     copyContent /* = true */,
-                                            bool                     writeValues /* = true */ )
+                                            Object*                    destination,
+                                            bool                       copyContent /* = true */,
+                                            bool                       writeValues /* = true */ )
 {
     CAFFA_ASSERT( source && destination );
 
@@ -214,8 +215,8 @@ void ObjectService::copyObjectFromRpcToCaf( const Object* source, caffa::ObjectH
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::unique_ptr<caffa::ObjectHandle> ObjectService::createCafObjectFromRpc( const Object*       source,
-                                                                          caffa::ObjectFactory* objectFactory )
+std::unique_ptr<caffa::ObjectHandle> ObjectService::createCafObjectFromRpc( const Object*         source,
+                                                                            caffa::ObjectFactory* objectFactory )
 {
     CAFFA_ASSERT( source );
     std::unique_ptr<caffa::ObjectHandle> destination(
@@ -227,7 +228,7 @@ std::unique_ptr<caffa::ObjectHandle> ObjectService::createCafObjectFromRpc( cons
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::vector<AbstractCallback*> ObjectService::registerCallbacks()
+std::vector<AbstractCallback*> ObjectService::createCallbacks()
 {
     typedef ObjectService Self;
     return {

--- a/GrpcInterface/cafGrpcObjectService.h
+++ b/GrpcInterface/cafGrpcObjectService.h
@@ -58,11 +58,12 @@ public:
     static caffa::Object* findCafObjectFromRpcObject( const Object& rpcObject );
     static caffa::Object* findCafObjectFromScriptNameAndAddress( const std::string& scriptClassName, uint64_t address );
 
-    static void copyObjectFromCafToRpc( const caffa::ObjectHandle* source,
-                                        Object*                    destination,
-                                        bool                       copyContent = true,
-                                        bool                       writeValues = true );
-    static void copyObjectFromRpcToCaf( const Object* source, caffa::ObjectHandle* destination );
+    static void copyProjectObjectFromCafToRpc( const caffa::ObjectHandle* source, Object* destination );
+    static void copyProjectObjectFromRpcToCaf( const Object* source, caffa::ObjectHandle* destination );
+
+    static void copyResultOrParameterObjectFromCafToRpc( const caffa::ObjectHandle* source, Object* destination );
+    static void copyResultOrParameterObjectFromRpcToCaf( const Object* source, caffa::ObjectHandle* destination );
+
     static std::unique_ptr<caffa::ObjectHandle> createCafObjectFromRpc( const Object*         source,
                                                                         caffa::ObjectFactory* objectFactory );
 

--- a/GrpcInterface/cafGrpcObjectService.h
+++ b/GrpcInterface/cafGrpcObjectService.h
@@ -64,8 +64,8 @@ public:
     static void copyResultOrParameterObjectFromCafToRpc( const caffa::ObjectHandle* source, Object* destination );
     static void copyResultOrParameterObjectFromRpcToCaf( const Object* source, caffa::ObjectHandle* destination );
 
-    static std::unique_ptr<caffa::ObjectHandle> createCafObjectFromRpc( const Object*         source,
-                                                                        caffa::ObjectFactory* objectFactory );
+    static std::unique_ptr<caffa::ObjectHandle>
+        createCafObjectFromRpc( const Object* source, caffa::ObjectFactory* objectFactory, bool copyDataValues );
 
     std::vector<AbstractCallback*> createCallbacks() override;
 };

--- a/GrpcInterface/cafGrpcObjectService.h
+++ b/GrpcInterface/cafGrpcObjectService.h
@@ -59,14 +59,14 @@ public:
     static caffa::Object* findCafObjectFromScriptNameAndAddress( const std::string& scriptClassName, uint64_t address );
 
     static void copyObjectFromCafToRpc( const caffa::ObjectHandle* source,
-                                        Object*                  destination,
-                                        bool                     copyContent = true,
-                                        bool                     writeValues = true );
+                                        Object*                    destination,
+                                        bool                       copyContent = true,
+                                        bool                       writeValues = true );
     static void copyObjectFromRpcToCaf( const Object* source, caffa::ObjectHandle* destination );
-    static std::unique_ptr<caffa::ObjectHandle> createCafObjectFromRpc( const Object*       source,
-                                                                      caffa::ObjectFactory* objectFactory );
+    static std::unique_ptr<caffa::ObjectHandle> createCafObjectFromRpc( const Object*         source,
+                                                                        caffa::ObjectFactory* objectFactory );
 
-    std::vector<AbstractCallback*> registerCallbacks() override;
+    std::vector<AbstractCallback*> createCallbacks() override;
 };
 
 } // namespace caffa::rpc

--- a/GrpcInterface/cafGrpcServer.cpp
+++ b/GrpcInterface/cafGrpcServer.cpp
@@ -151,7 +151,7 @@ public:
         // Spawn new CallData instances to serve new clients.
         for ( auto service : m_services )
         {
-            for ( auto callback : service->registerCallbacks() )
+            for ( auto callback : service->createCallbacks() )
             {
                 process( callback );
             }

--- a/GrpcInterface/cafGrpcServiceInterface.h
+++ b/GrpcInterface/cafGrpcServiceInterface.h
@@ -30,8 +30,8 @@ class AbstractCallback;
 class ServiceInterface
 {
 public:
-    virtual std::vector<AbstractCallback*> registerCallbacks() = 0;
-    virtual ~ServiceInterface()                                = default;
+    virtual std::vector<AbstractCallback*> createCallbacks() = 0;
+    virtual ~ServiceInterface()                              = default;
 };
 
 typedef caffa::Factory<ServiceInterface, size_t> ServiceFactory;

--- a/ProjectDataModel/Core/cafChildArrayField.h
+++ b/ProjectDataModel/Core/cafChildArrayField.h
@@ -95,7 +95,10 @@ public:
     [[nodiscard]] std::unique_ptr<ObjectHandle> removeChildObject( ObjectHandle* object ) override;
     [[nodiscard]] std::unique_ptr<DataType>     remove( ObjectHandle* object );
 
-    std::string dataType() const override { return std::string( "object[]:" ) + DataType::classKeywordStatic(); }
+    std::string dataType() const override
+    {
+        return std::string( "object:" ) + DataType::classKeywordStatic() + std::string( "[]" );
+    }
 
 private: // To be disabled
     CAFFA_DISABLE_COPY_AND_ASSIGN( ChildArrayField );

--- a/ProjectDataModel/Core/cafChildArrayField.h
+++ b/ProjectDataModel/Core/cafChildArrayField.h
@@ -95,10 +95,7 @@ public:
     [[nodiscard]] std::unique_ptr<ObjectHandle> removeChildObject( ObjectHandle* object ) override;
     [[nodiscard]] std::unique_ptr<DataType>     remove( ObjectHandle* object );
 
-    std::string dataType() const override
-    {
-        return std::string( "object:" ) + DataType::classKeywordStatic() + std::string( "[]" );
-    }
+    std::string dataType() const override { return std::string( "object[]" ); }
 
 private: // To be disabled
     CAFFA_DISABLE_COPY_AND_ASSIGN( ChildArrayField );

--- a/ProjectDataModel/Core/cafChildField.h
+++ b/ProjectDataModel/Core/cafChildField.h
@@ -71,7 +71,7 @@ public:
     [[nodiscard]] std::unique_ptr<DataType>     remove( ObjectHandle* object );
     [[nodiscard]] std::unique_ptr<ObjectHandle> removeChildObject( ObjectHandle* object ) override;
 
-    std::string dataType() const override { return std::string( "object:" ) + DataType::classKeywordStatic(); }
+    std::string dataType() const override { return std::string( "object" ); }
 
 private:
     CAFFA_DISABLE_COPY_AND_ASSIGN( ChildField );

--- a/ProjectDataModel/Core/cafPtrArrayField.h
+++ b/ProjectDataModel/Core/cafPtrArrayField.h
@@ -81,7 +81,7 @@ public:
     // Child objects
     virtual void ptrReferencedObjects( std::vector<ObjectHandle*>* );
 
-    std::string dataType() const override { return std::string( "object[]:" ) + DataType::classKeywordStatic(); }
+    std::string dataType() const override { return std::string( "object:" ) + DataType::classKeywordStatic() + "[]"; }
 
 private: // To be disabled
     CAFFA_DISABLE_COPY_AND_ASSIGN( PtrArrayField );

--- a/ProjectDataModel/Core/cafPtrArrayField.h
+++ b/ProjectDataModel/Core/cafPtrArrayField.h
@@ -81,7 +81,7 @@ public:
     // Child objects
     virtual void ptrReferencedObjects( std::vector<ObjectHandle*>* );
 
-    std::string dataType() const override { return std::string( "object:" ) + DataType::classKeywordStatic() + "[]"; }
+    std::string dataType() const override { return std::string( "object[]" ); }
 
 private: // To be disabled
     CAFFA_DISABLE_COPY_AND_ASSIGN( PtrArrayField );

--- a/ProjectDataModel/Core/cafPtrField.h
+++ b/ProjectDataModel/Core/cafPtrField.h
@@ -75,7 +75,7 @@ public:
 
     void ptrReferencedObjects( std::vector<ObjectHandle*>* objectsToFill ) override;
 
-    std::string dataType() const override { return std::string( "object:" ) + DataType::classKeywordStatic(); }
+    std::string dataType() const override { return std::string( "object" ); }
 
 private:
     CAFFA_DISABLE_COPY_AND_ASSIGN( PtrField );

--- a/ProjectDataModel/IoCore/IoCore_UnitTests/cafIoBasicTest.cpp
+++ b/ProjectDataModel/IoCore/IoCore_UnitTests/cafIoBasicTest.cpp
@@ -316,6 +316,6 @@ TEST( BaseTest, TestDataType )
     {
         auto obj      = std::make_unique<InheritedDemoObj>();
         auto dataType = obj->m_childArrayField.dataType();
-        EXPECT_EQ( std::string( "object:" ) + DemoObject::classKeywordStatic() + "[]", dataType );
+        EXPECT_EQ( std::string( "object[]" ), dataType );
     }
 }

--- a/ProjectDataModel/IoCore/IoCore_UnitTests/cafIoBasicTest.cpp
+++ b/ProjectDataModel/IoCore/IoCore_UnitTests/cafIoBasicTest.cpp
@@ -275,7 +275,7 @@ TEST( BaseTest, ChildArrayFieldSerializing )
 
         serializedString = ihd1->writeObjectToString();
 
-        std::cout << serializedString << std::endl;
+        std::cout << "Write object to json: " << serializedString << std::endl;
     }
 
     {
@@ -316,6 +316,6 @@ TEST( BaseTest, TestDataType )
     {
         auto obj      = std::make_unique<InheritedDemoObj>();
         auto dataType = obj->m_childArrayField.dataType();
-        EXPECT_EQ( std::string( "object[]:" ) + DemoObject::classKeywordStatic(), dataType );
+        EXPECT_EQ( std::string( "object:" ) + DemoObject::classKeywordStatic() + "[]", dataType );
     }
 }

--- a/ProjectDataModel/IoCore/cafFieldIoCapability.cpp
+++ b/ProjectDataModel/IoCore/cafFieldIoCapability.cpp
@@ -15,7 +15,6 @@ using namespace caffa;
 FieldIoCapability::FieldIoCapability( FieldHandle* owner, bool giveOwnership )
     : m_isIOReadable( true )
     , m_isIOWritable( true )
-    , m_isCopyable( true )
 {
     m_owner = owner;
     owner->addCapability( this, giveOwnership );
@@ -28,7 +27,6 @@ void FieldIoCapability::disableIO()
 {
     setIOReadable( false );
     setIOWritable( false );
-    setCopyable( false );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ProjectDataModel/IoCore/cafFieldIoCapability.h
+++ b/ProjectDataModel/IoCore/cafFieldIoCapability.h
@@ -33,19 +33,17 @@ public:
 
     bool isIOReadable() const { return m_isIOReadable; }
     bool isIOWritable() const { return m_isIOWritable; }
-    bool isCopyable() const { return m_isCopyable; }
 
     void disableIO();
     void setIOWritable( bool isWritable ) { m_isIOWritable = isWritable; }
     void setIOReadable( bool isReadable ) { m_isIOReadable = isReadable; }
-    void setCopyable( bool isCopyable ) { m_isCopyable = isCopyable; }
 
     virtual bool resolveReferences() = 0;
 
     virtual std::string referenceString() const { return std::string(); }
 
-    virtual void writeToField( const nlohmann::json& value, ObjectFactory* objectFactory )               = 0;
-    virtual void readFromField( nlohmann::json& value, bool writeServerAddress, bool writeValues ) const = 0;
+    virtual void writeToField( const nlohmann::json& value, ObjectFactory* objectFactory, bool copyDataValues ) = 0;
+    virtual void readFromField( nlohmann::json& value, bool copyServerAddress, bool copyDataValues ) const      = 0;
 
 protected:
     bool assertValid() const;
@@ -53,7 +51,6 @@ protected:
 protected:
     bool m_isIOReadable;
     bool m_isIOWritable;
-    bool m_isCopyable;
 
     FieldHandle* m_owner;
 };

--- a/ProjectDataModel/IoCore/cafFieldIoCapabilitySpecializations.h
+++ b/ProjectDataModel/IoCore/cafFieldIoCapabilitySpecializations.h
@@ -26,8 +26,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool resolveReferences() override;
 
@@ -51,8 +51,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool        resolveReferences() override;
     std::string referenceString() const override;
@@ -81,8 +81,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool        resolveReferences() override;
     std::string referenceString() const override;
@@ -109,8 +109,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool resolveReferences() override;
 
@@ -132,8 +132,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool resolveReferences() override;
 
@@ -156,8 +156,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool resolveReferences() override;
 
@@ -184,8 +184,8 @@ public:
 
 public:
     // Json Serializing
-    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory ) override;
-    void readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const override;
+    void writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues ) override;
+    void readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const override;
 
     bool resolveReferences() override;
 

--- a/ProjectDataModel/IoCore/cafFieldIoCapabilitySpecializations.inl
+++ b/ProjectDataModel/IoCore/cafFieldIoCapabilitySpecializations.inl
@@ -258,7 +258,7 @@ void FieldIoCap<ChildField<DataType*>>::writeToField( const nlohmann::json& json
     }
 
     // Everything seems ok, so read the contents of the object:
-    ObjectJsonCapability::readFieldsFronJson( obj, jsonObject, objectFactory, false );
+    ObjectJsonCapability::readFieldsFronJson( obj, jsonObject, objectFactory, copyDataValues );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -345,7 +345,7 @@ void FieldIoCap<ChildArrayField<DataType*>>::writeToField( const nlohmann::json&
             continue;
         }
 
-        ObjectJsonCapability::readFieldsFronJson( obj, jsonObject, objectFactory, false );
+        ObjectJsonCapability::readFieldsFronJson( obj, jsonObject, objectFactory, copyDataValues );
 
         m_field->m_pointers.push_back( Pointer<DataType>() );
         m_field->m_pointers.back().setRawPtr( obj );

--- a/ProjectDataModel/IoCore/cafFieldIoCapabilitySpecializations.inl
+++ b/ProjectDataModel/IoCore/cafFieldIoCapabilitySpecializations.inl
@@ -23,23 +23,26 @@ namespace caffa
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename FieldType>
-void FieldIoCap<FieldType>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory )
+void FieldIoCap<FieldType>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory, bool copyDataValues )
 {
     this->assertValid();
-    CAFFA_TRACE( "Setting value from json: " << jsonValue.dump() );
+    if ( copyDataValues )
+    {
+        CAFFA_TRACE( "Setting value from json: " << jsonValue.dump() );
 
-    typename FieldType::FieldDataType value = jsonValue.get<typename FieldType::FieldDataType>();
-    m_field->setValue( value );
+        typename FieldType::FieldDataType value = jsonValue.get<typename FieldType::FieldDataType>();
+        m_field->setValue( value );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename FieldType>
-void FieldIoCap<FieldType>::readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const
+void FieldIoCap<FieldType>::readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const
 {
     this->assertValid();
-    if ( writeValues )
+    if ( copyDataValues )
     {
         jsonValue = m_field->value();
     }
@@ -58,7 +61,9 @@ bool FieldIoCap<FieldType>::resolveReferences()
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<PtrField<DataType*>>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory )
+void FieldIoCap<PtrField<DataType*>>::writeToField( const nlohmann::json& jsonValue,
+                                                    ObjectFactory*        objectFactory,
+                                                    bool                  copyDataValues )
 {
     this->assertValid();
     std::string dataString = jsonValue.get<std::string>();
@@ -82,7 +87,7 @@ void FieldIoCap<PtrField<DataType*>>::writeToField( const nlohmann::json& jsonVa
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<PtrField<DataType*>>::readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const
+void FieldIoCap<PtrField<DataType*>>::readFromField( nlohmann::json& jsonValue, bool copyServerAddress, bool copyDataValues ) const
 {
     this->assertValid();
 
@@ -119,7 +124,9 @@ std::string FieldIoCap<PtrField<DataType*>>::referenceString() const
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<PtrArrayField<DataType*>>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory )
+void FieldIoCap<PtrArrayField<DataType*>>::writeToField( const nlohmann::json& jsonValue,
+                                                         ObjectFactory*        objectFactory,
+                                                         bool                  copyDataValues )
 {
     this->assertValid();
 
@@ -139,8 +146,8 @@ void FieldIoCap<PtrArrayField<DataType*>>::writeToField( const nlohmann::json& j
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
 void FieldIoCap<PtrArrayField<DataType*>>::readFromField( nlohmann::json& jsonValue,
-                                                          bool            writeServerAddress,
-                                                          bool            writeValues ) const
+                                                          bool            copyServerAddress,
+                                                          bool            copyDataValues ) const
 {
     this->assertValid();
 
@@ -195,7 +202,9 @@ std::string FieldIoCap<PtrArrayField<DataType*>>::referenceString() const
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<ChildField<DataType*>>::writeToField( const nlohmann::json& jsonObject, ObjectFactory* objectFactory )
+void FieldIoCap<ChildField<DataType*>>::writeToField( const nlohmann::json& jsonObject,
+                                                      ObjectFactory*        objectFactory,
+                                                      bool                  copyDataValues )
 {
     CAFFA_TRACE( "Writing " << jsonObject.dump() << " to ChildField" );
     if ( jsonObject.is_null() ) return;
@@ -249,14 +258,16 @@ void FieldIoCap<ChildField<DataType*>>::writeToField( const nlohmann::json& json
     }
 
     // Everything seems ok, so read the contents of the object:
-    ObjectJsonCapability::readFields( obj, jsonObject, objectFactory, false );
+    ObjectJsonCapability::readFieldsFronJson( obj, jsonObject, objectFactory, false );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<ChildField<DataType*>>::readFromField( nlohmann::json& jsonValue, bool writeServerAddress, bool writeValues ) const
+void FieldIoCap<ChildField<DataType*>>::readFromField( nlohmann::json& jsonValue,
+                                                       bool            copyServerAddress,
+                                                       bool            copyDataValues ) const
 {
     auto object = m_field->m_fieldValue.rawPtr();
     if ( !object ) return;
@@ -268,11 +279,11 @@ void FieldIoCap<ChildField<DataType*>>::readFromField( nlohmann::json& jsonValue
 
         nlohmann::json jsonObject  = nlohmann::json::object();
         jsonObject["classKeyword"] = className.c_str();
-        if ( writeServerAddress )
+        if ( copyServerAddress )
         {
             jsonObject["serverAddress"] = reinterpret_cast<uint64_t>( object );
         }
-        ObjectJsonCapability::writeFields( object, jsonObject, writeServerAddress, writeValues );
+        ObjectJsonCapability::writeFieldsToJson( object, jsonObject, copyServerAddress, copyDataValues );
         CAFFA_ASSERT( jsonObject.is_object() );
         jsonValue = jsonObject;
     }
@@ -291,7 +302,9 @@ bool FieldIoCap<ChildField<DataType*>>::resolveReferences()
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<ChildArrayField<DataType*>>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory )
+void FieldIoCap<ChildArrayField<DataType*>>::writeToField( const nlohmann::json& jsonValue,
+                                                           ObjectFactory*        objectFactory,
+                                                           bool                  copyDataValues )
 {
     m_field->clear();
 
@@ -332,7 +345,7 @@ void FieldIoCap<ChildArrayField<DataType*>>::writeToField( const nlohmann::json&
             continue;
         }
 
-        ObjectJsonCapability::readFields( obj, jsonObject, objectFactory, false );
+        ObjectJsonCapability::readFieldsFronJson( obj, jsonObject, objectFactory, false );
 
         m_field->m_pointers.push_back( Pointer<DataType>() );
         m_field->m_pointers.back().setRawPtr( obj );
@@ -344,8 +357,8 @@ void FieldIoCap<ChildArrayField<DataType*>>::writeToField( const nlohmann::json&
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
 void FieldIoCap<ChildArrayField<DataType*>>::readFromField( nlohmann::json& jsonValue,
-                                                            bool            writeServerAddress,
-                                                            bool            writeValues ) const
+                                                            bool            copyServerAddress,
+                                                            bool            copyDataValues ) const
 {
     typename std::vector<Pointer<DataType>>::iterator it;
 
@@ -361,11 +374,11 @@ void FieldIoCap<ChildArrayField<DataType*>>::readFromField( nlohmann::json& json
             std::string    className   = ioObject->classKeyword();
             nlohmann::json jsonObject  = nlohmann::json::object();
             jsonObject["classKeyword"] = className;
-            if ( writeServerAddress )
+            if ( copyServerAddress )
             {
                 jsonObject["serverAddress"] = reinterpret_cast<uint64_t>( it->rawPtr() );
             }
-            ObjectJsonCapability::writeFields( it->rawPtr(), jsonObject, writeServerAddress, writeValues );
+            ObjectJsonCapability::writeFieldsToJson( it->rawPtr(), jsonObject, copyServerAddress, copyDataValues );
             jsonArray.push_back( jsonObject );
         }
     }
@@ -414,7 +427,9 @@ public:
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<FifoBlockingField<DataType>>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory )
+void FieldIoCap<FifoBlockingField<DataType>>::writeToField( const nlohmann::json& jsonValue,
+                                                            ObjectFactory*        objectFactory,
+                                                            bool                  copyDataValues )
 {
     CAFFA_ASSERT( false && "Cannot write to a Fifo Field" );
 }
@@ -424,8 +439,8 @@ void FieldIoCap<FifoBlockingField<DataType>>::writeToField( const nlohmann::json
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
 void FieldIoCap<FifoBlockingField<DataType>>::readFromField( nlohmann::json& jsonValue,
-                                                             bool            writeServerAddress,
-                                                             bool            writeValues ) const
+                                                             bool            copyServerAddress,
+                                                             bool            copyDataValues ) const
 {
     this->assertValid();
     if ( !m_field->active() )
@@ -465,7 +480,9 @@ bool FieldIoCap<FifoBlockingField<DataType>>::resolveReferences()
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
-void FieldIoCap<FifoBoundedField<DataType>>::writeToField( const nlohmann::json& jsonValue, ObjectFactory* objectFactory )
+void FieldIoCap<FifoBoundedField<DataType>>::writeToField( const nlohmann::json& jsonValue,
+                                                           ObjectFactory*        objectFactory,
+                                                           bool                  copyDataValues )
 {
     CAFFA_ASSERT( false && "Cannot write to a Fifo Field" );
 }
@@ -475,8 +492,8 @@ void FieldIoCap<FifoBoundedField<DataType>>::writeToField( const nlohmann::json&
 //--------------------------------------------------------------------------------------------------
 template <typename DataType>
 void FieldIoCap<FifoBoundedField<DataType>>::readFromField( nlohmann::json& jsonValue,
-                                                            bool            writeServerAddress,
-                                                            bool            writeValues ) const
+                                                            bool            copyServerAddress,
+                                                            bool            copyDataValues ) const
 {
     this->assertValid();
     if ( !m_field->active() )

--- a/ProjectDataModel/IoCore/cafObjectIoCapability.cpp
+++ b/ProjectDataModel/IoCore/cafObjectIoCapability.cpp
@@ -26,7 +26,7 @@ ObjectIoCapability::ObjectIoCapability( ObjectHandle* owner, bool giveOwnership 
 //--------------------------------------------------------------------------------------------------
 ObjectHandle* ObjectIoCapability::readUnknownObjectFromString( const std::string& string,
                                                                ObjectFactory*     objectFactory,
-                                                               bool               isCopyOperation,
+                                                               bool               copyDataValues,
                                                                IoType             ioType /*= IoType::JSON */ )
 {
     ObjectHandle* object = nullptr;
@@ -36,7 +36,7 @@ ObjectHandle* ObjectIoCapability::readUnknownObjectFromString( const std::string
         default:
             break;
         case IoType::JSON:
-            object = ObjectJsonCapability::readUnknownObjectFromString( string, objectFactory, isCopyOperation );
+            object = ObjectJsonCapability::readUnknownObjectFromString( string, objectFactory, copyDataValues );
             break;
         case IoType::SQL:
             CAFFA_ASSERT( "SQL writing is not implemented" );
@@ -69,7 +69,7 @@ void ObjectIoCapability::readObjectFromString( const std::string& string,
 ///
 //--------------------------------------------------------------------------------------------------
 std::string ObjectIoCapability::writeObjectToString( IoType ioType /*= IoType::JSON */,
-                                                     bool   writeServerAddress /*= false */ ) const
+                                                     bool   copyServerAddress /*= false */ ) const
 {
     std::string string;
     switch ( ioType )
@@ -77,7 +77,7 @@ std::string ObjectIoCapability::writeObjectToString( IoType ioType /*= IoType::J
         default:
             break;
         case IoType::JSON:
-            string = ObjectJsonCapability::writeObjectToString( m_owner, writeServerAddress );
+            string = ObjectJsonCapability::writeObjectToString( m_owner, copyServerAddress );
             break;
         case IoType::SQL:
             CAFFA_ASSERT( "SQL writing is not implemented" );
@@ -90,7 +90,7 @@ std::string ObjectIoCapability::writeObjectToString( IoType ioType /*= IoType::J
 ///
 //--------------------------------------------------------------------------------------------------
 caffa::ObjectHandle* ObjectIoCapability::copyBySerialization( ObjectFactory* objectFactory,
-                                                            IoType         ioType /*= IoType::JSON */ )
+                                                              IoType         ioType /*= IoType::JSON */ )
 {
     switch ( ioType )
     {
@@ -110,9 +110,9 @@ caffa::ObjectHandle* ObjectIoCapability::copyBySerialization( ObjectFactory* obj
 ///
 //--------------------------------------------------------------------------------------------------
 caffa::ObjectHandle* ObjectIoCapability::copyAndCastBySerialization( const std::string& destinationClassKeyword,
-                                                                   const std::string& sourceClassKeyword,
-                                                                   ObjectFactory*     objectFactory,
-                                                                   IoType             ioType /*= IoType::JSON */ )
+                                                                     const std::string& sourceClassKeyword,
+                                                                     ObjectFactory*     objectFactory,
+                                                                     IoType             ioType /*= IoType::JSON */ )
 {
     switch ( ioType )
     {

--- a/ProjectDataModel/IoCore/cafObjectIoCapability.h
+++ b/ProjectDataModel/IoCore/cafObjectIoCapability.h
@@ -42,10 +42,10 @@ public:
 
     static ObjectHandle* readUnknownObjectFromString( const std::string& string,
                                                       ObjectFactory*     objectFactory,
-                                                      bool               isCopyOperation,
+                                                      bool               copyDataValues,
                                                       IoType             ioType = IoType::JSON );
     void readObjectFromString( const std::string& string, ObjectFactory* objectFactory, IoType ioType = IoType::JSON );
-    std::string writeObjectToString( IoType ioType = IoType::JSON, bool writeServerAddress = false ) const;
+    std::string writeObjectToString( IoType ioType = IoType::JSON, bool copyServerAddress = false ) const;
 
     ObjectHandle* copyBySerialization( ObjectFactory* objectFactory, IoType ioType = IoType::JSON );
 
@@ -66,7 +66,7 @@ public:
     bool writeFile( const std::string& fileName, IoType ioType = IoType::JSON );
 
     bool readFile( std::istream& istream, IoType ioType = IoType::JSON );
-    bool writeFile( std::ostream& ostream, IoType ioType = IoType::JSON, bool writeServerAddress = false );
+    bool writeFile( std::ostream& ostream, IoType ioType = IoType::JSON, bool copyServerAddress = false );
 
 protected: // Virtual
     /// Method gets called from Document after all objects are read.

--- a/ProjectDataModel/IoCore/cafObjectJsonCapability.cpp
+++ b/ProjectDataModel/IoCore/cafObjectJsonCapability.cpp
@@ -163,6 +163,7 @@ void ObjectJsonCapability::readFields( ObjectHandle*         object,
         }
         if ( valueIt == field.end() || valueIt->is_null() )
         {
+            assert( false );
             CAFFA_DEBUG( "Could not find value in " << field.dump() );
             continue;
         }

--- a/ProjectDataModel/IoCore/cafObjectJsonCapability.cpp
+++ b/ProjectDataModel/IoCore/cafObjectJsonCapability.cpp
@@ -18,7 +18,7 @@ using namespace caffa;
 void ObjectJsonCapability::readObjectFromString( ObjectHandle* object, const std::string& string, ObjectFactory* objectFactory )
 {
     nlohmann::json jsonValue = nlohmann::json::parse( string );
-    readFieldsFronJson( object, jsonValue, objectFactory, false );
+    readFieldsFronJson( object, jsonValue, objectFactory, true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -163,7 +163,6 @@ void ObjectJsonCapability::readFieldsFronJson( ObjectHandle*         object,
         }
         if ( copyDataValues && ( valueIt == field.end() || valueIt->is_null() ) )
         {
-            assert( false );
             CAFFA_DEBUG( "Could not find value in " << field.dump() );
             continue;
         }

--- a/ProjectDataModel/IoCore/cafObjectJsonCapability.h
+++ b/ProjectDataModel/IoCore/cafObjectJsonCapability.h
@@ -27,7 +27,7 @@ class ObjectJsonCapability
 public:
     /// Convenience methods to serialize/de-serialize this particular object (with children)
     static void readObjectFromString( ObjectHandle* object, const std::string& string, ObjectFactory* objectFactory );
-    static std::string   writeObjectToString( const ObjectHandle* object, bool writeServerAddress );
+    static std::string   writeObjectToString( const ObjectHandle* object, bool copyServerAddress );
     static ObjectHandle* copyByJsonSerialization( const ObjectHandle* object, ObjectFactory* objectFactory );
     static ObjectHandle* copyAndCastByJsonSerialization( const ObjectHandle* object,
                                                          const std::string&  destinationClassKeyword,
@@ -35,22 +35,22 @@ public:
                                                          ObjectFactory*      objectFactory );
 
     static ObjectHandle*
-        readUnknownObjectFromString( const std::string& string, ObjectFactory* objectFactory, bool isCopyOperation );
+        readUnknownObjectFromString( const std::string& string, ObjectFactory* objectFactory, bool copyDataValues );
 
     static void readFile( ObjectHandle* object, std::istream& file, ObjectFactory* objectFactory = nullptr );
     static void
-        writeFile( const ObjectHandle* object, std::ostream& file, bool writeServerAddress, bool writeValues = true );
+        writeFile( const ObjectHandle* object, std::ostream& file, bool copyServerAddress, bool copyDataValues = true );
 
     // Main XML serialization methods that is used internally by the document serialization system
     // Not supposed to be used directly.
-    static void readFields( ObjectHandle*         object,
-                            const nlohmann::json& jsonObject,
-                            ObjectFactory*        objectFactory,
-                            bool                  isCopyOperation );
-    static void writeFields( const ObjectHandle* object,
-                             nlohmann::json&     jsonObject,
-                             bool                writeServerAddress,
-                             bool                writeValues = true );
+    static void readFieldsFronJson( ObjectHandle*         object,
+                                    const nlohmann::json& jsonObject,
+                                    ObjectFactory*        objectFactory,
+                                    bool                  copyDataValues );
+    static void writeFieldsToJson( const ObjectHandle* object,
+                                   nlohmann::json&     jsonObject,
+                                   bool                copyServerAddress,
+                                   bool                copyDataValues = true );
 };
 
 } // End of namespace caffa

--- a/ProjectDataModel/ProjectDataModel_UnitTests/cafBasicTest.cpp
+++ b/ProjectDataModel/ProjectDataModel_UnitTests/cafBasicTest.cpp
@@ -319,6 +319,11 @@ TEST( BaseTest, ReadWrite )
         doc.fileName = "TestFile.json";
         doc.write();
 
+        {
+            std::ifstream f1( doc.fileName() );
+            std::string   str1( ( std::istreambuf_iterator<char>( f1 ) ), std::istreambuf_iterator<char>() );
+            CAFFA_DEBUG( "Wrote file content to " << doc.fileName() << ":\n" << str1 );
+        }
         caffa::ObjectGroup pog;
         for ( size_t i = 0; i < doc.objects.size(); i++ )
         {

--- a/ProjectDataModel/ProjectDataModel_UnitTests/cafProjectDataModel_UnitTests.cpp
+++ b/ProjectDataModel/ProjectDataModel_UnitTests/cafProjectDataModel_UnitTests.cpp
@@ -34,7 +34,10 @@
 //
 //##################################################################################################
 
+#include "cafLogger.h"
+
 #include "gtest.h"
+
 #include <iostream>
 #include <stdio.h>
 #include <string>
@@ -44,6 +47,7 @@
 //--------------------------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
+    caffa::Logger::setApplicationLogLevel( caffa::Logger::Level::DEBUG );
     testing::InitGoogleTest( &argc, argv );
     int result = RUN_ALL_TESTS();
     return result;


### PR DESCRIPTION
The array getters and setters are too complicated to be used for all purposes in Java code.

Also simplified gRPC objects to exclude class keyword and address and instead store this in the json. This makes the java code simpler.