### PR TITLE
Increase default timeout and decrease vectors transferred

### DIFF
--- a/Core/cafSession.h
+++ b/Core/cafSession.h
@@ -1,20 +1,20 @@
-//##################################################################################################
+// ##################################################################################################
 //
-//   Caffa
-//   Copyright (C) 2022- Kontur AS
+//    Caffa
+//    Copyright (C) 2022- Kontur AS
 //
-//   GNU Lesser General Public License Usage
-//   This library is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU Lesser General Public License as published by
-//   the Free Software Foundation; either version 2.1 of the License, or
-//   (at your option) any later version.
+//    GNU Lesser General Public License Usage
+//    This library is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation; either version 2.1 of the License, or
+//    (at your option) any later version.
 //
-//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
-//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-//   FITNESS FOR A PARTICULAR PURPOSE.
+//    This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//    WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//    FITNESS FOR A PARTICULAR PURPOSE.
 //
-//   See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
-//   for more details.
+//    See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
+//    for more details.
 //
 #pragma once
 
@@ -42,7 +42,7 @@ public:
     };
 
     static std::shared_ptr<Session> create( Type                      type,
-                                            std::chrono::milliseconds timeout = std::chrono::milliseconds( 500 ) );
+                                            std::chrono::milliseconds timeout = std::chrono::milliseconds( 1000 ) );
 
     ~Session() = default;
 

--- a/GrpcInterface/GrpcInterface_UnitTests/cafGrpcInterfaceBasicTest.cpp
+++ b/GrpcInterface/GrpcInterface_UnitTests/cafGrpcInterfaceBasicTest.cpp
@@ -1001,7 +1001,7 @@ TEST_F( GrpcTest, LocalResponseTimeAndDataTransfer )
 
         std::vector<float> serverVector;
         std::mt19937       rng;
-        size_t             numberOfFloats = 128 * 1024;
+        size_t             numberOfFloats = 12 * 1024;
         serverVector.reserve( numberOfFloats );
         for ( size_t i = 0; i < numberOfFloats; ++i )
         {


### PR DESCRIPTION
* When debug mode is used, the tests now take a lot longer